### PR TITLE
Update Telemetry to 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- [Reporter.Instrumenter] Bump telemetry version.
+
 ## [0.6.0] - 2019-03-18
 
 ### Added

--- a/lib/kiq.ex
+++ b/lib/kiq.ex
@@ -304,7 +304,7 @@ defmodule Kiq do
         end
       end
 
-      Telemetry.attach([:kiq, :job, :success], KiqJobLogger, :handle_event, nil)
+      :telemetry.attach([:kiq, :job, :success], &KiqJobLogger.handle_event/4, nil)
 
   Here is a reference for the available metrics:
 

--- a/lib/kiq/reporter/instrumenter.ex
+++ b/lib/kiq/reporter/instrumenter.ex
@@ -3,13 +3,11 @@ defmodule Kiq.Reporter.Instrumenter do
 
   use Kiq.Reporter
 
-  import Telemetry, only: [execute: 3]
-
   alias Kiq.Job
 
   @impl Reporter
   def handle_started(%Job{class: class, queue: queue}, state) do
-    execute([:kiq, :job, :started], 1, %{class: class, queue: queue})
+    :telemetry.execute([:kiq, :job, :started], %{value: 1}, %{class: class, queue: queue})
 
     state
   end
@@ -18,7 +16,7 @@ defmodule Kiq.Reporter.Instrumenter do
   def handle_success(%Job{class: class, queue: queue}, meta, state) do
     timing = Keyword.get(meta, :timing, 0)
 
-    execute([:kiq, :job, :success], timing, %{class: class, queue: queue})
+    :telemetry.execute([:kiq, :job, :success], %{timing: timing}, %{class: class, queue: queue})
 
     state
   end
@@ -27,14 +25,14 @@ defmodule Kiq.Reporter.Instrumenter do
   def handle_aborted(%Job{class: class, queue: queue}, meta, state) do
     reason = Keyword.get(meta, :reason, :unknown)
 
-    execute([:kiq, :job, :aborted], 1, %{class: class, queue: queue, reason: reason})
+    :telemetry.execute([:kiq, :job, :aborted], %{value: 1}, %{class: class, queue: queue, reason: reason})
 
     state
   end
 
   @impl Reporter
   def handle_failure(%Job{class: class, queue: queue}, error, _stack, state) do
-    execute([:kiq, :job, :failure], 1, %{class: class, queue: queue, error: error_name(error)})
+    :telemetry.execute([:kiq, :job, :failure], %{value: 1}, %{class: class, queue: queue, error: error_name(error)})
 
     state
   end

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Kiq.MixProject do
       {:gen_stage, "~> 0.14"},
       {:nimble_parsec, "~> 0.4.0"},
       {:redix, "~> 0.9"},
-      {:telemetry, "~> 0.2"},
+      {:telemetry, "~> 0.4"},
       {:benchee, "~> 0.13", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -11,5 +11,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
   "redix": {:hex, :redix, "0.9.0", "c631c921354587e054bf1e2a6b7d0120d617352fc42b624b9ca79ea484d0326c", [:mix], [], "hexpm"},
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
-  "telemetry": {:hex, :telemetry, "0.2.0", "5b40caa3efe4deb30fb12d7cd8ed4f556f6d6bd15c374c2366772161311ce377", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }

--- a/test/kiq/reporter/instrumenter_test.exs
+++ b/test/kiq/reporter/instrumenter_test.exs
@@ -4,7 +4,7 @@ defmodule Kiq.Reporter.InstrumenterTest do
   alias Kiq.Reporter.Instrumenter, as: Reporter
 
   def attach(type) do
-    Telemetry.attach("test-#{type}", [:kiq, :job, type], __MODULE__, :handle_event, nil)
+    :telemetry.attach("test-#{type}", [:kiq, :job, type], &handle_event/4, nil)
   end
 
   def handle_event([:kiq, :job, type], value, metadata, _config) do
@@ -18,9 +18,9 @@ defmodule Kiq.Reporter.InstrumenterTest do
 
     Reporter.handle_started(job, nil)
 
-    assert_received {:started, 1, %{class: "Worker", queue: "events"}}
+    assert_received {:started, %{value: 1}, %{class: "Worker", queue: "events"}}
   after
-    Telemetry.detach("test-started")
+    :telemetry.detach("test-started")
   end
 
   test "job success metrics are reported" do
@@ -30,9 +30,9 @@ defmodule Kiq.Reporter.InstrumenterTest do
 
     Reporter.handle_success(job, [timing: 123], nil)
 
-    assert_received {:success, 123, %{class: "Worker", queue: "events"}}
+    assert_received {:success, %{timing: 123}, %{class: "Worker", queue: "events"}}
   after
-    Telemetry.detach("test-success")
+    :telemetry.detach("test-success")
   end
 
   test "job aborted metrics are reported" do
@@ -42,9 +42,9 @@ defmodule Kiq.Reporter.InstrumenterTest do
 
     Reporter.handle_aborted(job, [reason: :expired], nil)
 
-    assert_received {:aborted, 1, %{class: "Worker", queue: "events", reason: :expired}}
+    assert_received {:aborted, %{value: 1}, %{class: "Worker", queue: "events", reason: :expired}}
   after
-    Telemetry.detach("test-aborted")
+    :telemetry.detach("test-aborted")
   end
 
   test "job failure metrics are reported" do
@@ -54,8 +54,8 @@ defmodule Kiq.Reporter.InstrumenterTest do
 
     Reporter.handle_failure(job, %RuntimeError{}, [], nil)
 
-    assert_received {:failure, 1, %{class: "Worker", queue: "events", error: "RuntimeError"}}
+    assert_received {:failure, %{value: 1}, %{class: "Worker", queue: "events", error: "RuntimeError"}}
   after
-    Telemetry.detach("test-failure")
+    :telemetry.detach("test-failure")
   end
 end


### PR DESCRIPTION
Updates telemetry to 0.4. This allows for easier integration with other libs in the ecosystem.